### PR TITLE
Update pdo_stmt.c; fix zval* being passed into zend_parse_parameters_ex

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1543,17 +1543,22 @@ static int register_bound_param(INTERNAL_FUNCTION_PARAMETERS, pdo_stmt_t *stmt, 
 	struct pdo_bound_param_data param = {{{0}}};
 	zend_long param_type = PDO_PARAM_STR;
 	zval *parameter;
+	zval *driver_params_ptr = NULL;
 
 	param.paramno = -1;
 
 	if (FAILURE == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(),
 			"lz|llz!", &param.paramno, &parameter, &param_type, &param.max_value_len,
-			&param.driver_params)) {
+			&driver_params_ptr)) {
 		if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|llz!", &param.name,
 				&parameter, &param_type, &param.max_value_len,
-				&param.driver_params)) {
+				&driver_params_ptr)) {
 			return 0;
 		}
+	}
+
+	if (driver_params_ptr != NULL) {
+		param.driver_params = *driver_params_ptr;
 	}
 
 	param.param_type = (int) param_type;


### PR DESCRIPTION
In pdo_stmt.c function `register_bound_param`:

pdo_stmt.c Line 1540

```
static int register_bound_param(INTERNAL_FUNCTION_PARAMETERS, pdo_stmt_t *stmt, int is_param)
{
    struct pdo_bound_param_data param = {{{0}}};
    zend_long param_type = PDO_PARAM_STR;
    zval *parameter;

    param.paramno = -1;

    if (FAILURE == zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(),
            "lz|llz!", &param.paramno, &parameter, &param_type, &param.max_value_len,
            &param.driver_params)) {
        if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|llz!", &param.name,
                &parameter, &param_type, &param.max_value_len,
                &param.driver_params)) {
            return 0;
        }
    }
```

`param` is initialized and from the `pdo_bound_param_data` struct we see that `param.driver_params` is a zval:

```
php_pdo_driver.h line 538
struct pdo_bound_param_data {
    zval parameter;

    zval driver_params;
    …
};
```

Thus when `&param.driver_params` is being passed into `zend_parse_parameter_ex`, it is a `zval*`.

The type spec being passed into the function is `“lz|llz!”`, and the corresponding type spec for `&param.driver_params` is `‘z’`. In the internals of zend, however, an argument with a type spec `‘z’` is evaluated as a `zval**`:

zend_API.c line 728

```
case 'z':
    {
        zval **p = va_arg(*va, zval **);

        zend_parse_arg_zval_deref(real_arg, p, check_null);
    }
```

The `zval*` is implicitly converted to a `zval**` since `va_arg` does not do any type checking. In the end, the result from `real_arg` is not parsed into `param.driver_params` correctly.
